### PR TITLE
drivers/ydn23.h: fix bad lchksum

### DIFF
--- a/drivers/ydn23.h
+++ b/drivers/ydn23.h
@@ -159,9 +159,9 @@ static inline void ydn23_lchecksum(uint16_t dlen, char *out)
 
 	/* Sum all four 4 bits */
 	lenchk += lelen & 0x000f;
-	lenchk += lelen & 0x00f0;
-	lenchk += lelen & 0x0f00;
-	lenchk += lelen & 0xf000;
+	lenchk += (lelen & 0x00f0) >> 4;
+	lenchk += (lelen & 0x0f00) >> 8;
+	lenchk += (lelen & 0xf000) >> 12;
 
 	lenchk %= 16;
 	lenchk = ~lenchk + 1;


### PR DESCRIPTION
Fix a bad checksum in length field. However, `liebert-gxe' was not affected because the frame never exceeds 2^4-1.